### PR TITLE
Bugfix/better set_label name

### DIFF
--- a/omnivoreql/omnivoreql.py
+++ b/omnivoreql/omnivoreql.py
@@ -226,3 +226,41 @@ class OmnivoreQL:
             gql(self.queries["DeleteLabel"]),
             variable_values={"id": label_id},
         )
+
+    def set_labels(
+        self,
+        page_id: str,
+        labels: Optional[List[CreateLabelInput]] = None,
+        label_ids: Optional[List[str]] = None,
+        source: str = "api",
+    ) -> dict:
+        """
+        Set labels for a page.
+
+        :param page_id: The ID of the page to set labels for.
+        :param label_ids: The IDs of the labels to set.
+        :param labels: The labels to set.
+        """
+        parsed_labels = (
+            [
+                {
+                    "name": label.name,
+                    "color": label.color,
+                    "description": label.description,
+                }
+                for label in labels
+            ]
+            if labels
+            else None
+        )
+        return self.client.execute(
+            gql(self.queries["ApplyLabels"]),
+            variable_values={
+                "input": {
+                    "pageId": page_id,
+                    "labelIds": label_ids,
+                    "labels": parsed_labels,
+                    "source": source,
+                }
+            },
+        )

--- a/omnivoreql/omnivoreql.py
+++ b/omnivoreql/omnivoreql.py
@@ -222,7 +222,7 @@ class OmnivoreQL:
             variable_values={"id": label_id},
         )
 
-    def set_page_labels_by_create_label_inputs(
+    def set_page_labels(
         self, page_id: str, labels: List[CreateLabelInput]
     ) -> dict:
         """
@@ -231,9 +231,9 @@ class OmnivoreQL:
         :param page_id: The ID of the page to set labels for.
         :param labels: The labels to set.
         """
-        return self.set_page_labels_by_labels(page_id, parsed_labels)
+        return self.set_page_labels_by_fields(page_id, parsed_labels)
 
-    def set_page_labels_by_labels(self, page_id: str, labels: List[dict]) -> dict:
+    def set_page_labels_by_fields(self, page_id: str, labels: List[dict]) -> dict:
         """
         Set labels for a page.
 
@@ -262,7 +262,7 @@ class OmnivoreQL:
             },
         )
 
-    def set_page_labels_by_label_ids(self, page_id: str, label_ids: List[str]) -> dict:
+    def set_page_labels_by_ids(self, page_id: str, label_ids: List[str]) -> dict:
         """
         Set labels for a page.
 

--- a/omnivoreql/omnivoreql.py
+++ b/omnivoreql/omnivoreql.py
@@ -4,7 +4,6 @@ import uuid
 from models import CreateLabelInput
 from dataclasses import asdict
 import os
-import glob
 from typing import List, Optional
 
 
@@ -26,38 +25,36 @@ class OmnivoreQL:
             use_json=True,
         )
         self.client = Client(transport=transport, fetch_schema_from_transport=False)
-        self.queries = self._load_queries("queries")
+        self.queries = {}
 
-    def _load_queries(self, queries_path: str) -> dict:
-        current_dir = os.path.dirname(os.path.abspath(__file__))
-        queries_path = os.path.join(current_dir, queries_path)
-        queries = {}
-        for file in glob.glob(f"{queries_path}/*.graphql"):
-            with open(file, "r") as f:
-                queries[os.path.basename(file).replace(".graphql", "")] = (
-                    f.read().replace("\n", " ")
-                )
-        return queries
+
+    def _get_query(self, query_name: str) -> str:
+        if query_name not in self.queries:
+            current_dir = os.path.dirname(os.path.abspath(__file__))
+            query_file_path = os.path.join(current_dir, f"queries/{query_name}.graphql")
+            with open(query_file_path, "r") as file:
+                self.queries[query_name] = gql(file.read())
+        return self.queries[query_name]
 
     def save_url(
         self,
         url: str,
         labels: Optional[List[str]] = None,
-        clientRequestId: str = str(uuid.uuid4()),
+        client_request_id: str = str(uuid.uuid4()),
     ):
         """
         Save a URL to Omnivore.
 
         :param url: The URL to save.
         :param labels: The labels to assign to the item.
-        :param clientRequestId: The client request ID.
+        :param client_request_id: The client request ID.
         """
         labels = [] if labels is None else [{"name": x} for x in labels]
         return self.client.execute(
-            gql(self.queries["SaveUrl"]),
+            self._get_query("SaveUrl"),
             variable_values={
                 "input": {
-                    "clientRequestId": clientRequestId,
+                    "clientRequestId": client_request_id,
                     "source": "api",
                     "url": url,
                     "labels": labels,
@@ -75,7 +72,7 @@ class OmnivoreQL:
         """
         labels = [] if labels is None else [{"name": x} for x in labels]
         return self.client.execute(
-            gql(self.queries["SavePage"]),
+            self._get_query("SavePage"),
             variable_values={
                 "input": {
                     "clientRequestId": str(uuid.uuid4()),
@@ -91,19 +88,19 @@ class OmnivoreQL:
         """
         Get the profile of the current user.
         """
-        return self.client.execute(gql(self.queries["Viewer"]))
+        return self.client.execute(self._get_query("Viewer"))
 
     def get_labels(self):
         """
         Get the labels of the current user.
         """
-        return self.client.execute(gql(self.queries["Labels"]))
+        return self.client.execute(self._get_query("Labels"))
 
     def get_subscriptions(self):
         """
         Get the subscriptions of the current user.
         """
-        return self.client.execute(gql(self.queries["GetSubscriptions"]))
+        return self.client.execute(self._get_query("GetSubscriptions"))
 
     def get_articles(
         self,
@@ -123,7 +120,7 @@ class OmnivoreQL:
         :param include_content: Whether to include the content of the articles.
         """
         return self.client.execute(
-            gql(self.queries["Search"]),
+            self._get_query("Search"),
             variable_values={
                 "first": limit,
                 "after": cursor,
@@ -142,7 +139,7 @@ class OmnivoreQL:
         :param format: The format of the article to return.
         """
         return self.client.execute(
-            gql(self.queries["ArticleContent"]),
+            self._get_query("ArticleContent"),
             variable_values={
                 "username": username,
                 "slug": slug,
@@ -158,7 +155,7 @@ class OmnivoreQL:
         :param to_archive: Whether to archive or unarchive the article.
         """
         return self.client.execute(
-            gql(self.queries["ArchiveSavedItem"]),
+            self._get_query("ArchiveSavedItem"),
             variable_values={"input": {"linkId": article_id, "archived": to_archive}},
         )
 
@@ -176,9 +173,8 @@ class OmnivoreQL:
 
         :param article_id: The ID of the article to delete.
         """
-        q = self.queries["DeleteSavedItem"]
         return self.client.execute(
-            gql(q),
+            self._get_query("DeleteSavedItem"),
             variable_values={"input": {"articleID": article_id, "bookmark": False}},
         )
 
@@ -189,7 +185,7 @@ class OmnivoreQL:
         :param label: An instance of LabelInput with the label data.
         """
         return self.client.execute(
-            gql(self.queries["CreateLabel"]),
+            self._get_query("CreateLabel"),
             variable_values={"input": asdict(label)},
         )
 
@@ -205,7 +201,7 @@ class OmnivoreQL:
         :param description: The description of the label.
         """
         return self.client.execute(
-            gql(self.queries["UpdateLabel"]),
+            self._get_query("UpdateLabel"),
             variable_values={
                 "input": {
                     "labelId": label_id,
@@ -223,7 +219,7 @@ class OmnivoreQL:
         :param label_id: The ID of the label to delete.
         """
         return self.client.execute(
-            gql(self.queries["DeleteLabel"]),
+            self._get_query("DeleteLabel"),
             variable_values={"id": label_id},
         )
 
@@ -240,6 +236,7 @@ class OmnivoreQL:
         :param page_id: The ID of the page to set labels for.
         :param label_ids: The IDs of the labels to set.
         :param labels: The labels to set.
+        :param source: The source of the call.
         """
         parsed_labels = (
             [
@@ -254,7 +251,7 @@ class OmnivoreQL:
             else None
         )
         return self.client.execute(
-            gql(self.queries["ApplyLabels"]),
+            self._get_query("ApplyLabels"),
             variable_values={
                 "input": {
                     "pageId": page_id,

--- a/tests/test_omnivoreql.py
+++ b/tests/test_omnivoreql.py
@@ -186,7 +186,7 @@ class TestOmnivoreQL(unittest.TestCase):
             label_sample["id"],
         )
 
-    def test_set_page_labels_by_labels(self):
+    def test_set_page_labels_by_fields(self):
         # Given
         page = self.client.get_articles(limit=1)["search"]["edges"][0]["node"]
         label_sample = self.sample_label
@@ -196,7 +196,7 @@ class TestOmnivoreQL(unittest.TestCase):
             label_sample["description"],
         )
         # When
-        result = self.client.set_page_labels_by_labels(page["id"], [created_label_input])
+        result = self.client.set_page_labels_by_fields(page["id"], [created_label_input])
         # Then
         self.assertIsNotNone(result)
         self.assertNotIn("errorCodes", result["setLabels"])
@@ -204,12 +204,12 @@ class TestOmnivoreQL(unittest.TestCase):
             result["setLabels"]["labels"][0]["id"], label_sample["id"]
         )
 
-    def test_set_page_labels_by_label_ids(self):
+    def test_set_page_labels_by_ids(self):
         # Given
         page = self.client.get_articles(limit=1)["search"]["edges"][0]["node"]
         label_sample = self.sample_label
         # When
-        result = self.client.set_page_labels_by_label_ids(
+        result = self.client.set_page_labels_by_ids(
             page["id"], label_ids=[label_sample["id"]]
         )
         # Then

--- a/tests/test_omnivoreql.py
+++ b/tests/test_omnivoreql.py
@@ -188,6 +188,19 @@ class TestOmnivoreQL(unittest.TestCase):
         except Exception as e:
             print(f"Error cleaning up labels: {e}")
 
+    def test_set_labels(self):
+        # Given
+        page = self.client.get_articles(limit=1)["search"]["edges"][0]["node"]
+        page_id = page["id"]
+        label_ids = [self.client.get_labels()["labels"]["labels"][0]["id"]]
+        # When
+        result = self.client.set_labels(page_id, label_ids=label_ids)
+        # Then
+        self.assertIsNotNone(result)
+        self.assertNotIn("errorCodes", result["setLabels"])
+        self.assertEqual(result["setLabels"]["pageId"], page_id)
+        self.assertListEqual(result["setLabels"]["labelIds"], label_ids)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request refactors the query loading mechanism, introduces new methods for setting page labels, and renames a parameter for consistency. It also includes updates and additions to the test suite to cover these changes.

- **New Features**:
    - Introduced methods `set_page_labels`, `set_page_labels_by_fields`, and `set_page_labels_by_ids` to set labels for a page.
- **Bug Fixes**:
    - Renamed `clientRequestId` to `client_request_id` for consistency.
- **Enhancements**:
    - Refactored query loading mechanism to load queries on demand using `_get_query` method.
- **Tests**:
    - Added tests for new methods `set_page_labels_by_fields` and `set_page_labels_by_ids`.
    - Updated existing tests to use the new `client_request_id` parameter and to include labels where applicable.
    - Enhanced test setup to clean up created labels from previous tests.

<!-- Generated by sourcery-ai[bot]: end summary -->